### PR TITLE
Fix Lighthouse errors by adding rel="noopener" to links

### DIFF
--- a/app/templates/ml_datasets.html
+++ b/app/templates/ml_datasets.html
@@ -70,10 +70,10 @@
     <div style="display: None">
         <div class="download_template">
             <div class="col-auto d-inline-block">
-                <a id="hdf5" class="btn btn-sm btn-download1 mr-lg-1" href="#" target="_blank">
+                <a id="hdf5" class="btn btn-sm btn-download1 mr-lg-1" href="#" target="_blank" rel="noopener">
                     <i class="fa fa-download d-none d-lg-inline"></i> HDF5
                 </a>
-                <a id="text" class="btn btn-sm btn-download2" href="#" target="_blank">
+                <a id="text" class="btn btn-sm btn-download2" href="#" target="_blank" rel="noopener">
                      <i class="fa fa-download d-none d-lg-inline"></i> Text
                 </a>
             </div>


### PR DESCRIPTION
Google told me to.

https://web.dev/external-anchors-use-rel-noopener/?utm_source=lighthouse&utm_medium=devtools