### PR TITLE
Switch to portal master

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -45,7 +45,7 @@ Flask-Cors
 Flask_Mongoengine
 Flask_Admin
 geoip2
-git+https://github.com/MolSSI/qcportal.git@master
+git+https://github.com/MolSSI/qcportal.git@master#egg=qcportal
 git+https://github.com/MolSSI/ml_models_deploy.git@master#egg=qc_time_estimator&subdirectory=models/qc_time_estimator
 qcelemental>=0.13.1
 natural


### PR DESCRIPTION
This PR switches the requirements to portal master (instead of portal 0.13.*). This will allow us to take advantages of fixes to portal in the RDS app between now and the release. Depending on timing, we might plan to have a portal release right before the RDS app launch.