### PR TITLE
[WIP] Letsencrypt

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -12,6 +12,13 @@ RUN apk --update add nginx && \
 
 COPY conf.d/app.conf /etc/nginx/conf.d/app.conf
 
-EXPOSE 80 443
-#EXPOSE 88 443
+EXPOSE 443
+
+RUN wget https://dl.eff.org/certbot-auto && \
+    mv certbot-auto /usr/local/bin/certbot-auto && \
+    chown root /usr/local/bin/certbot-auto && \
+    chmod 0755 /usr/local/bin/certbot-auto && \
+    /usr/local/bin/certbot-auto --nginx && \
+    echo "0 0,12 * * * root /usr/local/bin/certbot-auto renew -q" | sudo tee -a /etc/crontab > /dev/null
+
 CMD ["nginx", "-g", "daemon off;"]

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -11,6 +11,7 @@ RUN apk --update add nginx && \
     rm -rf /var/cache/apk/*
 
 COPY conf.d/app.conf /etc/nginx/conf.d/app.conf
+COPY boot.sh boot.sh
 
 EXPOSE 443
 
@@ -20,4 +21,4 @@ RUN apk add --no-cache certbot certbot-nginx && \
 RUN apk add --no-cache openrc busybox-initscripts && \
     rc-update add crond
 
-CMD ["certbot", "--nginx;", "nginx", "-g", "daemon off;"]
+CMD "./boot.sh"

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -15,9 +15,8 @@ COPY conf.d/app.conf /etc/nginx/conf.d/app.conf
 EXPOSE 443
 
 RUN apk add --no-cache certbot certbot-nginx && \
-    certbot --nginx && \
     echo "0 0,12 * * * root python -c 'import random; import time; time.sleep(random.random() * 3600)' && certbot renew -q" | sudo tee -a /etc/crontab > /dev/null
 
-RUN rc-service crond start && rc-update add crond
+RUN rc-update add crond
 
-CMD ["nginx", "-g", "daemon off;"]
+CMD ["nginx", "-g", "daemon off;", "certbot", "--nginx"]

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -14,7 +14,7 @@ COPY conf.d/app.conf /etc/nginx/conf.d/app.conf
 COPY boot.sh boot.sh
 RUN chmod +x boot.sh
 
-EXPOSE 443
+EXPOSE 80 443
 
 RUN apk add --no-cache certbot certbot-nginx && \
     echo "0 0,12 * * * root python -c 'import random; import time; time.sleep(random.random() * 3600)' && certbot renew -q" | tee -a /etc/crontab > /dev/null

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -15,8 +15,8 @@ COPY conf.d/app.conf /etc/nginx/conf.d/app.conf
 EXPOSE 443
 
 RUN apk add --no-cache certbot certbot-nginx && \
-    echo "0 0,12 * * * root python -c 'import random; import time; time.sleep(random.random() * 3600)' && certbot renew -q" | sudo tee -a /etc/crontab > /dev/null
+    echo "0 0,12 * * * root python -c 'import random; import time; time.sleep(random.random() * 3600)' && certbot renew -q" | tee -a /etc/crontab > /dev/null
 
 RUN rc-update add crond
 
-CMD ["nginx", "-g", "daemon off;", "certbot", "--nginx"]
+CMD ["certbot", "--nginx;", "nginx", "-g", "daemon off;"]

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -14,11 +14,10 @@ COPY conf.d/app.conf /etc/nginx/conf.d/app.conf
 
 EXPOSE 443
 
-RUN wget https://dl.eff.org/certbot-auto && \
-    mv certbot-auto /usr/local/bin/certbot-auto && \
-    chown root /usr/local/bin/certbot-auto && \
-    chmod 0755 /usr/local/bin/certbot-auto && \
-    /usr/local/bin/certbot-auto --nginx && \
-    echo "0 0,12 * * * root /usr/local/bin/certbot-auto renew -q" | sudo tee -a /etc/crontab > /dev/null
+RUN apk add --no-cache certbot certbot-nginx && \
+    certbot --nginx && \
+    echo "0 0,12 * * * root python -c 'import random; import time; time.sleep(random.random() * 3600)' && certbot renew -q" | sudo tee -a /etc/crontab > /dev/null
+
+RUN rc-service crond start && rc-update add crond
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -17,6 +17,7 @@ EXPOSE 443
 RUN apk add --no-cache certbot certbot-nginx && \
     echo "0 0,12 * * * root python -c 'import random; import time; time.sleep(random.random() * 3600)' && certbot renew -q" | tee -a /etc/crontab > /dev/null
 
-RUN apk add --no-cache openrc && rc-update add crond
+RUN apk add --no-cache openrc busybox-initscripts && \
+    rc-update add crond
 
 CMD ["certbot", "--nginx;", "nginx", "-g", "daemon off;"]

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -17,6 +17,6 @@ EXPOSE 443
 RUN apk add --no-cache certbot certbot-nginx && \
     echo "0 0,12 * * * root python -c 'import random; import time; time.sleep(random.random() * 3600)' && certbot renew -q" | tee -a /etc/crontab > /dev/null
 
-RUN rc-update add crond
+RUN apk add --no-cache openrc && rc-update add crond
 
 CMD ["certbot", "--nginx;", "nginx", "-g", "daemon off;"]

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -12,6 +12,7 @@ RUN apk --update add nginx && \
 
 COPY conf.d/app.conf /etc/nginx/conf.d/app.conf
 COPY boot.sh boot.sh
+RUN chmod +x boot.sh
 
 EXPOSE 443
 

--- a/nginx/boot.sh
+++ b/nginx/boot.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+certbot --nginx
+nginx -g daemon off;

--- a/nginx/boot.sh
+++ b/nginx/boot.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-certbot --nginx --non-interactive --agree-tos -m qcarchive@molssi.org
-nginx -g "daemon off;"
+nginx
+certbot --nginx --non-interactive --agree-tos -m qcarchive@molssi.org -d qcarchive-webapps.eastus.cloudapp.azure.com

--- a/nginx/boot.sh
+++ b/nginx/boot.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 
-nginx
+
 certbot --nginx --non-interactive --agree-tos -m qcarchive@molssi.org -d qcarchive-webapps.eastus.cloudapp.azure.com
+nginx -g "daemon off;"

--- a/nginx/boot.sh
+++ b/nginx/boot.sh
@@ -2,4 +2,6 @@
 
 
 certbot --nginx --non-interactive --agree-tos -m qcarchive@molssi.org -d qcarchive-webapps.eastus.cloudapp.azure.com
+kill $(ps aux | grep '[n]ginx' | awk '{print $2}')  # certbot can't kill nginx cleanly?
+sleep 3
 nginx -g "daemon off;"

--- a/nginx/boot.sh
+++ b/nginx/boot.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-
+nginx
 certbot --nginx --non-interactive --agree-tos -m qcarchive@molssi.org -d qcarchive-webapps.eastus.cloudapp.azure.com
-kill $(ps aux | grep '[n]ginx' | awk '{print $2}')  # certbot can't kill nginx cleanly?
-sleep 3
-nginx -g "daemon off;"
+while true; do sleep 1; done

--- a/nginx/boot.sh
+++ b/nginx/boot.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 certbot --nginx
-nginx -g daemon off;
+nginx -g "daemon off;"

--- a/nginx/boot.sh
+++ b/nginx/boot.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-certbot --nginx
+certbot --nginx --non-interactive --agree-tos -m qcarchive@molssi.org
 nginx -g "daemon off;"

--- a/nginx/conf.d/app.conf
+++ b/nginx/conf.d/app.conf
@@ -3,7 +3,7 @@ upstream app_server {
 }
 
 server {
-    listen 443;
+    listen 80;
     server_name qcarchive-webapps.eastus.cloudapp.azure.com;
     error_log  /var/log/nginx/error.log;
     access_log /var/log/nginx/access.log;

--- a/nginx/conf.d/app.conf
+++ b/nginx/conf.d/app.conf
@@ -3,8 +3,8 @@ upstream app_server {
 }
 
 server {
-    listen 80;
-    server_name _;
+    listen 443;
+    server_name qcarchive-webapps.eastus.cloudapp.azure.com;
     error_log  /var/log/nginx/error.log;
     access_log /var/log/nginx/access.log;
     client_max_body_size 64M;


### PR DESCRIPTION
I've reached the point of diminishing returns on this one. It looks like everything goes well until certbot tries to restart nginx. Maybe @dgasmith or @doaa-altarawy, your experience with nginx will resolve this issue.

```
IMPORTANT NOTES:
 - Congratulations! Your certificate and chain have been saved at:
   /etc/letsencrypt/live/qcarchivecertbottest.eastus.cloudapp.azure.com/fullchain.pem
   Your key file has been saved at:
   /etc/letsencrypt/live/qcarchivecertbottest.eastus.cloudapp.azure.com/privkey.pem
   Your cert will expire on 2020-06-07. To obtain a new or tweaked
   version of this certificate in the future, simply run certbot again
   with the "certonly" option. To non-interactively renew *all* of
   your certificates, run "certbot renew"
 - If you like Certbot, please consider supporting our work by:

   Donating to ISRG / Let's Encrypt:   https://letsencrypt.org/donate
   Donating to EFF:                    https://eff.org/donate-le

 * ERROR: nginx stopped by something else
nginx: [emerg] bind() to 0.0.0.0:443 failed (98: Address in use)
nginx: [emerg] bind() to 0.0.0.0:80 failed (98: Address in use)
nginx: [emerg] bind() to 0.0.0.0:443 failed (98: Address in use)
nginx: [emerg] bind() to 0.0.0.0:80 failed (98: Address in use)
nginx: [emerg] bind() to 0.0.0.0:443 failed (98: Address in use)
nginx: [emerg] bind() to 0.0.0.0:80 failed (98: Address in use)
nginx: [emerg] bind() to 0.0.0.0:443 failed (98: Address in use)
nginx: [emerg] bind() to 0.0.0.0:80 failed (98: Address in use)
nginx: [emerg] bind() to 0.0.0.0:443 failed (98: Address in use)
nginx: [emerg] bind() to 0.0.0.0:80 failed (98: Address in use)
nginx: [emerg] still could not bind()
```
(Note that in this case, I was using the correct DNS name -- different from the one in this PR.)